### PR TITLE
Update to work with critical ^2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,12 +35,13 @@ Options
 {
   base: {webpack.output.path},
   src: 'index.html',
-  dest: 'index.html',
+  target: 'index.css',
   inline: true,
   minify: true,
   extract: true,
   width: 375,
   height: 565,
+  concurrency: 4,
   penthouse: {
     blockJSRequests: false
   }

--- a/index.js
+++ b/index.js
@@ -5,12 +5,13 @@ class CriticalCssWebpackPlugin {
   constructor (options) {
     this.options = Object.assign({
       src: 'index.html',
-      dest: 'index.html',
+      target: 'index.css',
       inline: true,
       minify: true,
       extract: true,
       width: 375,
       height: 565,
+      concurrency: 4,
       penthouse: {
         blockJSRequests: false
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "critical-css-webpack-plugin",
-  "version": "0.2.0",
+  "version": "2.0.0",
   "main": "index.js",
   "license": "MIT",
   "devDependencies": {
@@ -12,6 +12,6 @@
     "eslint-plugin-standard": "^3.0.1"
   },
   "peerDependencies": {
-    "critical": "^1.3.3"
+    "critical": "^2.0.0"
   }
 }


### PR DESCRIPTION
Updated it to work with `critical` `^2.0.0` and also bumped the version to match the version of `critical` it's pinned to, so `2.0.0`

Mostly just refactoring `dest` -> `target` and adding `concurrency` options